### PR TITLE
排除okhttp中okio依赖

### DIFF
--- a/okhttps/pom.xml
+++ b/okhttps/pom.xml
@@ -21,6 +21,12 @@
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<version>${okhttp.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>okio</artifactId>
+					<groupId>com.squareup.okio</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okio</groupId>


### PR DESCRIPTION
手动引入的okio依赖版本为1.17.5, okhttp中使用的依赖为1.17.2. 虽然实际使用时已经被替换指向到1.17.5版本, 但强迫症患者表示红色代码看不下去.
![image](https://user-images.githubusercontent.com/23135144/146708438-1887f7d2-1ae2-4a34-ac89-54835ad36c79.png)
